### PR TITLE
Add bare output mode, Enable ~/.passcode usage

### DIFF
--- a/src/authenticator/cli.py
+++ b/src/authenticator/cli.py
@@ -592,6 +592,8 @@ class CLI:
                 print("", file=self.__stdout)
             first_time = False
             soonest_expiration = self._generate_once(cds_to_calc, bare=bare)
+            if bare:
+                return
             if soonest_expiration is None:
                 # we only calculate counter-based HOTPs once
                 keep_going = False


### PR DESCRIPTION
This PR contains code from @rirze to enable bare output and enable usage of ~/.passcode file,
alongside my changes to exit after the first code is output, so that app can be used in conjunction with cli tools, like `pbcopy` on OSX.

Fixes #9 